### PR TITLE
Resolve server.js path so it can find it from everywhere

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,9 @@
 
 var atom = require('atom-shell')
 var proc = require('child_process')
+var path = require('path')
+
+var serverPath = path.join(__dirname, 'server.js')
 
 var md = process.argv[2]
 if (!md) {
@@ -10,4 +13,4 @@ if (!md) {
 }
 
 // spawn atom-shell
-var child = proc.spawn(atom, ['./server.js', md])
+var child = proc.spawn(atom, [serverPath, md])


### PR DESCRIPTION
When starting the program from outside its own repository repository it couldn't find `server.js`. This patch resolves the full path to `server.js`.