### PR TITLE
Adds automatic reload on file change

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "atom-shell": "^0.21.2",
+    "chokidar": "^1.0.0-rc3",
     "github-markdown-css": "^2.0.3",
     "marked": "^0.3.3"
   },

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const assert = require('assert')
 const app = require('app')
 const ipc = require('ipc')
 const fs = require('fs')
+const chokidar = require('chokidar')
 
 require('crash-reporter').start()
 
@@ -10,6 +11,10 @@ const mainWindow = null
 
 const filePath = process.argv[2]
 assert(filePath, 'no file path specified')
+
+const watcher = chokidar.watch(filePath, {
+  usePolling: true
+})
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {
@@ -19,11 +24,15 @@ app.on('window-all-closed', function () {
 app.on('ready', function () {
   window = new BrowserWindow({ width: 800, height: 600 })
   window.loadUrl('file://' + __dirname + '/index.html')
-  window.webContents.on('did-finish-load', function () {
-    var file = fs.readFileSync(filePath, { encoding: 'utf8' })
-    window.webContents.send('md', file)
-  })
+  window.webContents.on('did-finish-load', sendMarkdown)
   window.on('closed', function () {
     mainWindow = null
   })
+
+  watcher.on('change', sendMarkdown)
+
+  function sendMarkdown () {
+      var file = fs.readFileSync(filePath, { encoding: 'utf8' })
+      window.webContents.send('md', file)
+  }
 })


### PR DESCRIPTION
This change reloads the content when the file changes using chokidar.

Notice `usePolling: true`. This is because chokidar would stop noticing changes after 2 times when editing the file with Vim. `usePolling` seems to have fixed it. I don't know why though.

