### PR TITLE
Resolves relative image paths

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,8 +1,11 @@
 const marked = require('marked')
 const ipc = require('ipc')
+const remote = require('remote')
 
 ipc.on('md', function (raw) {
   const md = marked(raw)
+  const base = document.querySelector('base');
   const body = document.querySelector('.markdown-body')
+  base.setAttribute('href', remote.getGlobal('baseUrl'))
   body.innerHTML = md
 })

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <head>
-  <link 
-    rel="stylesheet" 
+  <link
+    rel="stylesheet"
     href="node_modules/github-markdown-css/github-markdown.css">
   <style>
       .markdown-body {
@@ -10,6 +10,7 @@
           padding: 30px;
       }
   </style>
+  <base>
 <body class="markdown-body">
   <script src="./client.js"></script>
 </body>

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const assert = require('assert')
 const app = require('app')
 const ipc = require('ipc')
 const fs = require('fs')
+const path = require('path')
 
 require('crash-reporter').start()
 
@@ -10,6 +11,8 @@ const mainWindow = null
 
 const filePath = process.argv[2]
 assert(filePath, 'no file path specified')
+
+global.baseUrl = path.dirname(filePath) + '/'
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const mainWindow = null
 const filePath = process.argv[2]
 assert(filePath, 'no file path specified')
 
-global.baseUrl = path.dirname(filePath) + '/'
+global.baseUrl = path.relative(__dirname, path.resolve(path.dirname(filePath))) + '/'
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {


### PR DESCRIPTION
Adds a `<base href="...">` tag to the head with the directory path of the markdown file being rendered. This way images with relative paths will be resolved relative to the markdown file. Currently the were relative to index.html.

It does so by adding the path to the `global` global and reads it in the renderer process using `require('remote').getGlobal()`. 