### PR TITLE
atom-shell is now called Electron

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const proc = require('child_process')
-const atom = require('atom-shell')
+const electron = require('electron-prebuilt')
 const path = require('path')
 const fs = require('fs')
 
@@ -17,5 +17,5 @@ if (!fs.existsSync(path.resolve(md))) {
   process.exit(1)
 }
 
-// spawn atom-shell
-proc.spawn(atom, [serverPath, md])
+// spawn electron
+proc.spawn(electron, [serverPath, md])

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "atom-shell": "^0.21.2",
+    "electron-prebuilt": "^0.24.0",
     "chokidar": "^1.0.0-rc3",
     "github-markdown-css": "^2.0.3",
     "highlight.js": "^8.4.0",


### PR DESCRIPTION
With version 0.24.0 atom-shell has been renamed to Electron.

There's a new npm module called [electron-prebuilt](https://www.npmjs.com/package/electron-prebuilt) that replaces the [atom-shell](https://www.npmjs.com/package/atom-shell) module. The old module doesn't seem to be getting any more updates as it's still at version 0.22.3. So I think we should be using the new one.