### PR TITLE
build: add prebuilt versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ npm-debug.log
 
 # osx
 .DS_Store
+
+# build
+*-linux
+*.app

--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ const fs = require('fs')
 crashReporter.start()
 
 const filePath = process.argv[2]
-assert(filePath, 'no file path specified')
+if (!filePath) {
+  console.log('no file path specified')
+  process.exit(1)
+}
 
 global.baseUrl = path.relative(__dirname, path.resolve(path.dirname(filePath)))
 if (global.baseUrl) global.baseUrl += '/'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build-linux": "electron-packager . vmd --platform=linux --arch=x64 --version=0.26.1",
     "clean": "rm -rf *.app && rm -rf *-linux",
     "publish": "publish-release --template notes.md --assets vmd.zip",
+    "start": "electron . README.md",
     "test": "standard"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "vmd",
   "main": "server.js",
   "scripts": {
+    "build": "npm run clean && npm run build-darwin",
+    "build-darwin": "electron-packager . vmd --platform=darwin --arch=x64 --version=0.26.1",
+    "build-linux": "electron-packager . vmd --platform=linux --arch=x64 --version=0.26.1",
+    "clean": "rm -rf *.app && rm -rf *-linux",
+    "publish": "publish-release --template notes.md --assets vmd.zip",
     "test": "standard"
   },
   "bin": {
@@ -19,13 +24,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "electron-prebuilt": "^0.24.0",
     "chokidar": "^1.0.0-rc3",
+    "electron-prebuilt": "^0.26.1",
     "github-markdown-css": "^2.0.3",
     "highlight.js": "^8.4.0",
     "marked": "^0.3.3"
   },
   "devDependencies": {
+    "electron-packager": "^4.1.1",
+    "publish-release": "^1.0.2",
     "standard": "^2.10.0"
   }
 }


### PR DESCRIPTION
Took the implementation from [monu](https://github.com/maxogden/monu/blob/master/package.json#L10-L11). Haven't gotten a linux version working, PR's welcome for that. Closes #24.
### Changes
- **build**: add release script to `package.json`
