### PR TITLE
closing the window should quit the process on OSX

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ const watcher = chokidar.watch(filePath, { usePolling: true })
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit()
+  app.quit()
 })
 
 app.on('ready', function () {


### PR DESCRIPTION
Since there is no way to re-open the window once you close it, seems like the process should also quit.

The reason the Electron docs use that "darwin" check in their examples is because some apps, like Chrome, will continue running on OSX when you close all the tabs (so that you can Cmd + N to open a new tab).