### PR TITLE
Add stdin support

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,21 +1,25 @@
 #!/usr/bin/env node
-const proc = require('child_process')
+const spawn = require('child_process').spawn
 const electron = require('electron-prebuilt')
 const path = require('path')
 const fs = require('fs')
 
 const serverPath = path.join(__dirname, '../server.js')
-
 const md = process.argv[2]
-if (!md) {
-  console.error('No file path specified')
-  process.exit(1)
-}
+var args = [serverPath]
 
-if (!fs.existsSync(path.resolve(md))) {
-  console.error('Cannot access ', md + ': No such file')
-  process.exit(1)
+if (md) {
+  if (!fs.existsSync(path.resolve(md))) {
+    console.error('Cannot access ', md + ': No such file')
+    process.exit(1)
+  }
+  args.push(md)
 }
 
 // spawn electron
-proc.spawn(electron, [serverPath, md])
+var proc = spawn(electron, args)
+
+// pipe stdin into child process
+if (!md) {
+  process.stdin.pipe(proc.stdin)
+}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,12 +14,15 @@ if (md) {
     process.exit(1)
   }
   args.push(md)
+} else if (process.stdin.isTTY) {
+  console.error('No file path specified')
+  process.exit(1)
 }
 
 // spawn electron
 var proc = spawn(electron, args)
 
-// pipe stdin into child process
+// pipe stdin into child process, if something was piped in
 if (!md) {
   process.stdin.pipe(proc.stdin)
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "electron-prebuilt": "^0.24.0",
     "chokidar": "^1.0.0-rc3",
+    "electron-prebuilt": "^0.24.0",
+    "get-stdin": "^4.0.1",
     "github-markdown-css": "^2.0.3",
     "highlight.js": "^8.4.0",
     "marked": "^0.3.3"

--- a/server.js
+++ b/server.js
@@ -2,20 +2,32 @@
 const BrowserWindow = require('browser-window')
 const crashReporter = require('crash-reporter')
 const chokidar = require('chokidar')
-const assert = require('assert')
 const path = require('path')
 const app = require('app')
 const fs = require('fs')
+const getStdin = require('get-stdin')
 
 crashReporter.start()
 
 const filePath = process.argv[2]
-assert(filePath, 'no file path specified')
+const fromFile = Boolean(filePath)
+var stdin, window
 
-global.baseUrl = path.relative(__dirname, path.resolve(path.dirname(filePath)))
+if (!fromFile) {
+  getStdin(function (body) {
+    stdin = body.toString()
+    sendMarkdown()
+  })
+}
+
+const resolved = fromFile ? path.resolve(path.dirname(filePath)) : process.cwd()
+global.baseUrl = path.relative(__dirname, resolved)
 if (global.baseUrl) global.baseUrl += '/'
 
-const watcher = chokidar.watch(filePath, { usePolling: true })
+var watcher 
+if (fromFile) {
+  watcher = chokidar.watch(filePath, { usePolling: true })
+}
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {
@@ -23,8 +35,9 @@ app.on('window-all-closed', function () {
 })
 
 app.on('ready', function () {
+  var prefix = fromFile ? (path.basename(filePath) + ' - ') : ''
   window = new BrowserWindow({
-    title: path.basename(filePath) + ' - vmd',
+    title: prefix + 'vmd',
     icon: path.join(__dirname, 'resources/vmd.png'),
     width: 800,
     height: 600
@@ -33,10 +46,16 @@ app.on('ready', function () {
   window.loadUrl('file://' + __dirname + '/index.html')
   window.webContents.on('did-finish-load', sendMarkdown)
 
-  watcher.on('change', sendMarkdown)
-
-  function sendMarkdown () {
-    var file = fs.readFileSync(filePath, { encoding: 'utf8' })
-    window.webContents.send('md', file)
+  if (fromFile) {
+    watcher.on('change', sendMarkdown)
   }
 })
+
+function sendMarkdown () {
+  if (window) {
+    var contents = fromFile
+      ? fs.readFileSync(filePath, { encoding: 'utf8' })
+      : stdin
+    window.webContents.send('md', contents)
+  }
+}

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ const resolved = fromFile ? path.resolve(path.dirname(filePath)) : process.cwd()
 global.baseUrl = path.relative(__dirname, resolved)
 if (global.baseUrl) global.baseUrl += '/'
 
-var watcher 
+var watcher
 if (fromFile) {
   watcher = chokidar.watch(filePath, { usePolling: true })
 }


### PR DESCRIPTION
Built atop @mattdesl's work on #28 to fix #18. I added a bit of code that has the CLI process bail if stdin is a TTY (i.e. nothing is being piped in). Oh, and a trivial bit of whitespace that was making `standard` balk.