### PR TITLE
Add ability to zoom in and out, fixes #43

### DIFF
--- a/client.js
+++ b/client.js
@@ -21,7 +21,7 @@ window.addEventListener('keydown', function (ev) {
   if (ev.keyCode === 27) remote.getCurrentWindow().close()
 })
 
-var zoom = require('./zoom')();
+var zoom = require('./zoom')()
 
 // menu
 var vmdSubmenu = [
@@ -49,9 +49,9 @@ var template = [
   {
     label: 'View',
     submenu: [
-      { label: 'Zoom In', accelerator: 'CmdOrCtrl+Plus', click: function () { zoom.zoomIn(); } },
-      { label: 'Zoom Out', accelerator: 'CmdOrCtrl+-', click: function () { zoom.zoomOut(); } },
-      { label: 'Reset Zoom', accelerator: 'CmdOrCtrl+0', click: function () { zoom.reset(); } }
+      { label: 'Zoom In', accelerator: 'CmdOrCtrl+Plus', click: function () { zoom.zoomIn() } },
+      { label: 'Zoom Out', accelerator: 'CmdOrCtrl+-', click: function () { zoom.zoomOut() } },
+      { label: 'Reset Zoom', accelerator: 'CmdOrCtrl+0', click: function () { zoom.reset() } }
     ]
   }
 ]

--- a/client.js
+++ b/client.js
@@ -21,6 +21,8 @@ window.addEventListener('keydown', function (ev) {
   if (ev.keyCode === 27) remote.getCurrentWindow().close()
 })
 
+var zoom = require('./zoom')();
+
 // menu
 var vmdSubmenu = [
   { label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: function () { remote.require('app').quit() } }
@@ -38,9 +40,18 @@ var template = [
     label: 'vmd',
     submenu: vmdSubmenu
   },
-  { label: 'File',
+  {
+    label: 'File',
     submenu: [
       { label: 'Print', accelerator: 'CmdOrCtrl+P', click: function () { window.print() } }
+    ]
+  },
+  {
+    label: 'View',
+    submenu: [
+      { label: 'Zoom In', accelerator: 'CmdOrCtrl+Plus', click: function () { zoom.zoomIn(); } },
+      { label: 'Zoom Out', accelerator: 'CmdOrCtrl+-', click: function () { zoom.zoomOut(); } },
+      { label: 'Reset Zoom', accelerator: 'CmdOrCtrl+0', click: function () { zoom.reset(); } }
     ]
   }
 ]

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
     }
   </style>
   <base>
-<body class="markdown-body">
+<body>
+  <div class="markdown-body"></div>
   <script src="./client.js"></script>
 </body>

--- a/zoom.js
+++ b/zoom.js
@@ -1,0 +1,27 @@
+var zoom = {
+  init: function () {
+    this.currentZoom = +window.getComputedStyle(document.body).getPropertyValue('zoom')
+    return this
+  },
+
+  update: function () {
+    document.body.style.zoom = this.currentZoom
+  },
+
+  zoomIn: function () {
+    this.currentZoom += 0.1
+    this.update()
+  },
+
+  zoomOut: function () {
+    this.currentZoom -= 0.1
+    this.update()
+  },
+
+  reset: function () {
+    this.currentZoom = 1
+    this.update()
+  }
+}
+
+module.exports = zoom.init.bind(zoom)


### PR DESCRIPTION
Adds the ability to zoom in and out for visually impaired people or people who like text bigger  or smaller.

 - Adds a "View" menu with "Zoom In", "Zoom Out" and "Reset Zoom" entries
 - Adds accelerators `Ctrl++` (zoom in), `Ctrl+-` (zoom out), `Ctrl+0` (reset zoom) or `Command+*` on Mac.
 - Increases or decreases zoom in 10%-steps.
 - Fixes #43