### PR TITLE
Persistent settings

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,10 +3,12 @@ const spawn = require('child_process').spawn
 const electron = require('electron-prebuilt')
 const path = require('path')
 const fs = require('fs')
+const conf = require('../config')
 
 const serverPath = path.join(__dirname, '../server.js')
-const md = process.argv[2] || (process.stdin.isTTY ? 'README.md' : null)
-var args = [serverPath]
+const md = conf._[0] || (process.stdin.isTTY ? conf.document : null)
+
+var args = [ serverPath ].concat([].concat(process.argv).splice(2))
 
 if (md) {
   var stat

--- a/client.js
+++ b/client.js
@@ -2,6 +2,7 @@ const highlightjs = require('highlight.js')
 const marked = require('marked')
 const remote = require('remote')
 const ipc = require('ipc')
+const conf = remote.getGlobal('conf')
 
 marked.setOptions({
   highlight: function (code, lang) {
@@ -21,7 +22,7 @@ window.addEventListener('keydown', function (ev) {
   if (ev.keyCode === 27) remote.getCurrentWindow().close()
 })
 
-var zoom = require('./zoom')()
+var zoom = require('./zoom')(conf.zoom)
 
 // menu
 var vmdSubmenu = [

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+const path = require('path')
+const fs = require('fs')
+
+const defaults = fs.readFileSync(path.join(__dirname, 'defaults.yml'), 'utf-8')
+
+const aliases = {
+  d: 'devtools',
+  z: 'zoom'
+}
+
+module.exports = require('rucola')('vmd', defaults, aliases)

--- a/defaults.yml
+++ b/defaults.yml
@@ -1,0 +1,3 @@
+---
+document: README.md
+zoom: 1

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "get-stdin": "^4.0.1",
     "github-markdown-css": "^2.0.3",
     "highlight.js": "^8.4.0",
-    "marked": "^0.3.3"
+    "marked": "^0.3.3",
+    "rucola": "^1.1.1"
   },
   "devDependencies": {
     "standard": "^2.10.0"

--- a/server.js
+++ b/server.js
@@ -6,10 +6,11 @@ const path = require('path')
 const app = require('app')
 const fs = require('fs')
 const getStdin = require('get-stdin')
+const conf = global.conf = require('./config')
 
 crashReporter.start()
 
-const filePath = process.argv[2]
+const filePath = conf._[0]
 const fromFile = Boolean(filePath)
 var stdin, window
 
@@ -45,6 +46,10 @@ app.on('ready', function () {
 
   window.loadUrl('file://' + __dirname + '/index.html')
   window.webContents.on('did-finish-load', sendMarkdown)
+
+  if (conf.devtools) {
+    window.openDevTools()
+  }
 
   if (fromFile) {
     watcher.on('change', sendMarkdown)

--- a/zoom.js
+++ b/zoom.js
@@ -1,5 +1,11 @@
 var zoom = {
-  init: function () {
+  init: function (zoom) {
+    if (zoom) {
+      this.currentZoom = +zoom
+      this.update()
+      return this
+    }
+
     this.currentZoom = +window.getComputedStyle(document.body).getPropertyValue('zoom')
     return this
   },


### PR DESCRIPTION
This adds the ability to have persistent settings in a configuration file and allows to override them using command-line arguments or environment variables.

Config files can be stored in `~/.vmdrc`, `~/.vmd/config`, `~/.config/vmd`, or any other standard config path (where you'd put your dot-files) and can be written as JSON, INI or YAML files.

Default values are in `defaults.yml`.

Here's what a config file for vmd in YAML format might look like:

`~/.vmdrc`:
```yaml
---
zoom: 1.5
```

The value can be overridden by providing a command-line argument:

```sh
vmd README.md --zoom=1.25
```

 - Adds new dependency *rucola*, a runtime configuration loader: `npm view rucola readme | vmd`
 - Opens the door for other settings / options like requested in issue #19.
 - Adds the ability to make the preferred zoom factor configurable.
 - Adds the ability to make the default document name (README.md) configurable.
 - Adds the ability to start vmd with the developer tools opened by using the `--devtools` flag.