### PR TITLE
OS X - Set represented filename

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,6 +53,10 @@ app.on('ready', function () {
 
   if (fromFile) {
     watcher.on('change', sendMarkdown)
+    // (OS X) Set represented filename (icon in menu bar)
+    if (process.platform === 'darwin') {
+      window.setRepresentedFilename(path.resolve(filePath))
+    }
   }
 })
 

--- a/server.js
+++ b/server.js
@@ -53,7 +53,7 @@ app.on('ready', function () {
 
   if (fromFile) {
     watcher.on('change', sendMarkdown)
-    // (OS X) Set represented filename (icon in menu bar)
+    // (OS X) Set represented filename (icon in title bar)
     if (process.platform === 'darwin') {
       window.setRepresentedFilename(path.resolve(filePath))
     }


### PR DESCRIPTION
The 'represented filename' is now set on OS X, meaning that the icon object of the currently open file (not applicable for STDIN) appears in the title bar and can be dragged out, right-clicked, etc.

![](http://i.imgur.com/afLbk1H.png)