### PR TITLE
No lang code block fix

### DIFF
--- a/client.js
+++ b/client.js
@@ -6,7 +6,7 @@ const conf = remote.getGlobal('conf')
 
 marked.setOptions({
   highlight: function (code, lang) {
-    return highlightjs.highlightAuto(code, [ lang ]).value
+    return highlightjs.highlightAuto(code, [ lang || 'plain' ]).value
   }
 })
 

--- a/client.js
+++ b/client.js
@@ -11,11 +11,29 @@ marked.setOptions({
 })
 
 ipc.on('md', function (raw) {
-  const md = marked(raw)
-  const base = document.querySelector('base')
-  const body = document.querySelector('.markdown-body')
-  base.setAttribute('href', remote.getGlobal('baseUrl'))
-  body.innerHTML = md
+  try {
+    const md = marked(raw)
+    const base = document.querySelector('base')
+    const body = document.querySelector('.markdown-body')
+    base.setAttribute('href', remote.getGlobal('baseUrl'))
+    body.innerHTML = md
+  } catch (e) {
+    document.body.style.color = 'white'
+    document.body.style.background = 'red'
+
+    const errorTitle = document.createElement('h1')
+    errorTitle.textContent = e.type + ': ' + e.message
+    errorTitle.style.fontSize = '20px'
+    errorTitle.style.margin = '1em 0.5em'
+    document.body.appendChild(errorTitle)
+
+    const errorBody = document.createElement('pre')
+    errorBody.textContent = e.stack
+    errorBody.style.fontSize = '14px'
+    errorBody.style.margin = '0 0.5em'
+    errorBody.style.whiteSpace = 'pre-wrap'
+    document.body.appendChild(errorBody)
+  }
 })
 
 window.addEventListener('keydown', function (ev) {


### PR DESCRIPTION
Given markdown like this where the code is just indented rather than the github flavor triple backticks.

``` md
Text

    code
```

This function:

``` js
marked.setOptions({
  highlight: function (code, lang) {
```

Is called with lang as undefined, and highlightjs expects a string, so it crashes and displays a blank page.

---

This also shows an error visually if there is one instead of displaying a blank page.
