### PR TITLE
enable Copy and Select All

### DIFF
--- a/client.js
+++ b/client.js
@@ -55,8 +55,8 @@ var template = [
   {
     label: 'Edit',
     submenu: [
-        { label: 'Copy', accelerator: 'CmdOrCtrl+C', click: function() { document.execCommand("copy") } },
-        { label: 'Select All', accelerator: 'CmdOrCtrl+A', click: function() { document.execCommand("selectAll") } }
+        { label: 'Copy', accelerator: 'CmdOrCtrl+C', click: function () { document.execCommand('copy') } },
+        { label: 'Select All', accelerator: 'CmdOrCtrl+A', click: function () { document.execCommand('selectAll') } }
     ]
   },
   {

--- a/client.js
+++ b/client.js
@@ -55,8 +55,8 @@ var template = [
   {
     label: 'Edit',
     submenu: [
-      { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
-      { label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:' }
+        { label: 'Copy', accelerator: 'CmdOrCtrl+C', click: function() { document.execCommand("copy") } },
+        { label: 'Select All', accelerator: 'CmdOrCtrl+A', click: function() { document.execCommand("selectAll") } }
     ]
   },
   {

--- a/client.js
+++ b/client.js
@@ -53,6 +53,13 @@ var template = [
     ]
   },
   {
+    label: 'Edit',
+    submenu: [
+      { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
+      { label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:' }
+    ]
+  },
+  {
     label: 'View',
     submenu: [
       { label: 'Zoom In', accelerator: 'CmdOrCtrl+Plus', click: function () { zoom.zoomIn() } },


### PR DESCRIPTION
Related to Issue #51  - I enabled Select All and Copy items in the Edit menu, along with corresponding keyboard shortcuts.
I tested with OS X 10.11 and Ubuntu 15.04. I don't have a windows box to test with, but should work there as well.

