### PR TITLE
Handle links

### DIFF
--- a/client.js
+++ b/client.js
@@ -119,7 +119,13 @@ function handleLink (ev) {
     }
   }
 
-  shell.openExternal(ev.target.href)
+  if (/^[a-z0-9-_]+:/g.test(href)) {
+    try {
+      shell.openExternal(ev.target.href)
+    } catch (ex) {
+      console.log(ex)
+    }
+  }
 }
 
 marked.setOptions({

--- a/client.js
+++ b/client.js
@@ -37,6 +37,14 @@ function scrollToHash (hash) {
   }
 }
 
+function changeFile (filePath) {
+  ipc.send('change-file', filePath)
+}
+
+function openFile (filePath) {
+  ipc.send('open-file', filePath)
+}
+
 function handleLink (ev) {
   const filePath = document.body.getAttribute('data-filepath')
   const href = ev.target.getAttribute('href')
@@ -63,8 +71,11 @@ function handleLink (ev) {
         }
 
         if (isMarkdownPath(pathname)) {
-          console.log('MARKDOWN FILE')
-          return
+          if (ev.shiftKey) {
+            return openFile(pathname)
+          }
+
+          return changeFile(pathname)
         }
 
         return shell.openItem(pathname)

--- a/create-window.js
+++ b/create-window.js
@@ -1,0 +1,107 @@
+const path = require('path')
+const fs = require('fs')
+const BrowserWindow = require('electron').BrowserWindow
+const ipc = require('electron').ipcMain
+const chokidar = require('chokidar')
+const assign = require('object-assign')
+
+const defaultOptions = {
+  width: 800,
+  height: 600
+}
+
+module.exports = function createWindow (options) {
+  options = assign({}, defaultOptions, options)
+
+  const fromFile = typeof options.filePath !== 'undefined'
+  var watcher
+
+  const win = new BrowserWindow({
+    icon: path.join(__dirname, 'resources/vmd.png'),
+    width: options.width,
+    height: options.height
+  })
+
+  updateTitle()
+
+  win.loadURL('file://' + __dirname + '/index.html')
+  win.on('close', onClose)
+  win.webContents.on('did-finish-load', sendMarkdown)
+
+  if (options.devTools) {
+    win.openDevTools()
+  }
+
+  if (fromFile) {
+    watcher = chokidar.watch(options.filePath, { usePolling: true })
+    watcher.on('change', sendMarkdown)
+  }
+
+  ipc.on('change-file', function (ev, filePath) {
+    if (ev.sender === win.webContents) {
+      changeFile(filePath)
+    }
+  })
+
+  ipc.on('open-file', function (ev, filePath) {
+    if (ev.sender === win.webContents) {
+      createWindow({
+        filePath: filePath,
+        devTools: options.devTools
+      })
+    }
+  })
+
+  function onClose () {
+    if (watcher) {
+      watcher.close()
+    }
+  }
+
+  function updateTitle () {
+    var prefix = fromFile ? (path.basename(options.filePath) + ' - ') : ''
+
+    win.setTitle(prefix + 'vmd')
+
+    // (OS X) Set represented filename (icon in title bar)
+    if (fromFile && process.platform === 'darwin') {
+      win.setRepresentedFilename(path.resolve(options.filePath))
+    }
+  }
+
+  function changeFile (filePath) {
+    if (watcher) {
+      watcher.unwatch(options.filePath)
+      watcher.add(filePath)
+    }
+
+    options.filePath = filePath
+    sendMarkdown()
+  }
+
+  function sendMarkdown () {
+    const resolved = fromFile
+      ? path.resolve(path.dirname(options.filePath))
+      : process.cwd()
+
+    var baseUrl = path.relative(__dirname, resolved)
+    if (baseUrl) baseUrl += '/'
+
+    if (win) {
+      var contents = fromFile
+        ? fs.readFileSync(options.filePath, { encoding: 'utf8' })
+        : options.contents
+
+      win.webContents.send('md', {
+        filePath: options.filePath,
+        baseUrl: baseUrl,
+        contents: contents
+      })
+    }
+  }
+
+  return {
+    win: win,
+    changeFile: changeFile
+  }
+}

--- a/create-window.js
+++ b/create-window.js
@@ -16,7 +16,7 @@ module.exports = function createWindow (options) {
   const fromFile = typeof options.filePath !== 'undefined'
   var watcher
 
-  const win = new BrowserWindow({
+  var win = new BrowserWindow({
     icon: path.join(__dirname, 'resources/vmd.png'),
     width: options.width,
     height: options.height

--- a/create-window.js
+++ b/create-window.js
@@ -86,6 +86,7 @@ module.exports = function createWindow (options) {
     }
 
     options.filePath = filePath
+    updateTitle()
     sendMarkdown()
   }
 

--- a/history.js
+++ b/history.js
@@ -1,0 +1,90 @@
+const deepEqual = require('deep-equal')
+
+module.exports = function () {
+  var history = []
+  var currentPosition = null
+
+  function cut () {
+    if (currentPosition !== null) {
+      history = history.slice(0, currentPosition + 1)
+    }
+  }
+
+  function push (item) {
+    if (deepEqual(item, current())) {
+      return current()
+    }
+
+    cut()
+    history.push(item)
+
+    if (currentPosition === null) {
+      currentPosition = 0
+    } else {
+      currentPosition += 1
+    }
+
+    return current()
+  }
+
+  function canGoBack (steps) {
+    if (typeof steps === 'undefined') {
+      steps = 1
+    }
+
+    return currentPosition - steps >= 0
+  }
+
+  function canGoForward (steps) {
+    if (typeof steps === 'undefined') {
+      steps = 1
+    }
+
+    return currentPosition + steps <= history.length - 1
+  }
+
+  function back (steps) {
+    if (typeof steps === 'undefined') {
+      steps = 1
+    }
+
+    if (canGoBack(steps)) {
+      currentPosition -= steps
+    } else {
+      currentPosition = 0
+    }
+
+    return current()
+  }
+
+  function forward (steps) {
+    if (typeof steps === 'undefined') {
+      steps = 1
+    }
+
+    if (canGoForward(steps)) {
+      currentPosition += steps
+    } else {
+      currentPosition = history.length - 1
+    }
+
+    return current()
+  }
+
+  function current () {
+    if (!history.length) {
+      return null
+    }
+
+    return history[currentPosition]
+  }
+
+  return {
+    push: push,
+    canGoBack: canGoBack,
+    canGoForward: canGoForward,
+    back: back,
+    forward: forward,
+    current: current
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "chokidar": "^1.4.1",
+    "deep-equal": "^1.0.1",
     "electron-prebuilt": "0.36.2",
     "get-stdin": "^5.0.1",
     "github-markdown-css": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "github-markdown-css": "^2.1.1",
     "highlight.js": "^9.0.0",
     "marked": "^0.3.3",
+    "object-assign": "^4.0.1",
     "rucola": "^1.1.2"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -22,10 +22,6 @@ if (!fromFile) {
     })
 }
 
-const resolved = fromFile ? path.resolve(path.dirname(filePath)) : process.cwd()
-global.baseUrl = path.relative(__dirname, resolved)
-if (global.baseUrl) global.baseUrl += '/'
-
 var watcher
 if (fromFile) {
   watcher = chokidar.watch(filePath, { usePolling: true })
@@ -62,10 +58,22 @@ app.on('ready', function () {
 })
 
 function sendMarkdown () {
+  const resolved = fromFile
+    ? path.resolve(path.dirname(filePath))
+    : process.cwd()
+
+  var baseUrl = path.relative(__dirname, resolved)
+  if (baseUrl) baseUrl += '/'
+
   if (window) {
     var contents = fromFile
       ? fs.readFileSync(filePath, { encoding: 'utf8' })
       : stdin
-    window.webContents.send('md', contents)
+
+    window.webContents.send('md', {
+      filePath: filePath,
+      baseUrl: baseUrl,
+      contents: contents
+    })
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,31 +1,13 @@
-/*global window:true*/
 const app = require('electron').app
-const BrowserWindow = require('electron').BrowserWindow
 const crashReporter = require('electron').crashReporter
-const chokidar = require('chokidar')
-const path = require('path')
-const fs = require('fs')
 const getStdin = require('get-stdin')
+const createWindow = require('./create-window')
 const conf = global.conf = require('./config')
 
 crashReporter.start()
 
 const filePath = conf._[0]
 const fromFile = Boolean(filePath)
-var stdin, window
-
-if (!fromFile) {
-  getStdin()
-    .then(function (body) {
-      stdin = body.toString()
-      sendMarkdown()
-    })
-}
-
-var watcher
-if (fromFile) {
-  watcher = chokidar.watch(filePath, { usePolling: true })
-}
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {
@@ -33,47 +15,18 @@ app.on('window-all-closed', function () {
 })
 
 app.on('ready', function () {
-  var prefix = fromFile ? (path.basename(filePath) + ' - ') : ''
-  window = new BrowserWindow({
-    title: prefix + 'vmd',
-    icon: path.join(__dirname, 'resources/vmd.png'),
-    width: 800,
-    height: 600
-  })
-
-  window.loadURL('file://' + __dirname + '/index.html')
-  window.webContents.on('did-finish-load', sendMarkdown)
-
-  if (conf.devtools) {
-    window.openDevTools()
-  }
-
-  if (fromFile) {
-    watcher.on('change', sendMarkdown)
-    // (OS X) Set represented filename (icon in title bar)
-    if (process.platform === 'darwin') {
-      window.setRepresentedFilename(path.resolve(filePath))
-    }
-  }
-})
-
-function sendMarkdown () {
-  const resolved = fromFile
-    ? path.resolve(path.dirname(filePath))
-    : process.cwd()
-
-  var baseUrl = path.relative(__dirname, resolved)
-  if (baseUrl) baseUrl += '/'
-
-  if (window) {
-    var contents = fromFile
-      ? fs.readFileSync(filePath, { encoding: 'utf8' })
-      : stdin
-
-    window.webContents.send('md', {
+  if (!fromFile) {
+    getStdin()
+      .then(function (body) {
+        createWindow({
+          contents: body.toString(),
+          devTools: conf.devtools
+        })
+      })
+  } else {
+    createWindow({
       filePath: filePath,
-      baseUrl: baseUrl,
-      contents: contents
+      devTools: conf.devtools
     })
   }
-}
+})


### PR DESCRIPTION
Handle links in the markdown documents. This will fix #14.

This puts a single "click" event handler on the `document` and if the target is a link (`<a/>` tag) it decides what to do with it based on the `href` and such. This is easier than registering event handlers on each `<a/>` tag separately because every time the document changes (we have file watching) the handlers would have to be registered again.

 - ~~_Does anybody know how I can spawn a new vmd?_~~
 - _Only tested on Linux so far. Please try it out on OS X and Windows._
 - _Opinions and ideas are welceome._

Checklist:

 - [x] Open external `http(s):` and `mailto:` links in default browser
 - [x] Open directories in the file manager
 - [x] Open files with the OS' default handler
 - [x] Scroll to section for "hash" links (`#something`)
 - [x] Open links to markdown files in the same window
 - [x] Open links to markdown files in a new window if `Shift` key is pressed
 - [x] Go back and forth in the history when navigating within the same window: History menu and `Alt+Left/Right` keyboard shortcuts