### PR TITLE
Put application menu creating in main process and expose an api (fixes #59)

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,0 +1,55 @@
+/*global vmd:true*/
+
+const electron = {
+  ipc: require('electron').ipcRenderer
+}
+
+// no var/let/const on purpose
+vmd = {
+  changeFile: function (filePath) {
+    electron.ipc.send('change-file', filePath)
+  },
+
+  openFile: function (filePath) {
+    electron.ipc.send('open-file', filePath)
+  },
+
+  on: function (eventName, listener) {
+    if (!electron.ipc) { return }
+    electron.ipc.on(eventName, listener)
+  },
+
+  off: function (eventName, listener) {
+    if (!electron.ipc) { return }
+    if (typeof listener !== 'function') { return }
+    return electron.ipc.removeListener(eventName, listener)
+  },
+
+  onPrintAction: function (callback) {
+    vmd.on('print', callback)
+  },
+
+  onHistoryBackAction: function (callback) {
+    vmd.on('history-back', callback)
+  },
+
+  onHistoryForwardAction: function (callback) {
+    vmd.on('history-forward', callback)
+  },
+
+  onZoomInAction: function (callback) {
+    vmd.on('zoom-in', callback)
+  },
+
+  onZoomOutAction: function (callback) {
+    vmd.on('zoom-out', callback)
+  },
+
+  onZoomResetAction: function (callback) {
+    vmd.on('zoom-reset', callback)
+  },
+
+  onContent: function (callback) {
+    vmd.on('md', callback)
+  }
+}

--- a/create-window.js
+++ b/create-window.js
@@ -16,7 +16,10 @@ module.exports = function createWindow (options) {
   const fromFile = typeof options.filePath !== 'undefined'
   var watcher
 
+  var preloadPath = path.resolve(__dirname, 'api.js')
+
   var win = new BrowserWindow({
+    preload: preloadPath,
     icon: path.join(__dirname, 'resources/vmd.png'),
     width: options.width,
     height: options.height

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const app = require('electron').app
 const crashReporter = require('electron').crashReporter
+const Menu = require('electron').Menu
 const getStdin = require('get-stdin')
 const createWindow = require('./create-window')
 const conf = global.conf = require('./config')
@@ -15,6 +16,8 @@ app.on('window-all-closed', function () {
 })
 
 app.on('ready', function () {
+  addApplicationMenu()
+
   if (!fromFile) {
     getStdin()
       .then(function (body) {
@@ -30,3 +33,125 @@ app.on('ready', function () {
     })
   }
 })
+
+function addApplicationMenu () {
+  // menu
+  var vmdSubmenu = [
+    {
+      label: 'Quit',
+      accelerator: 'CmdOrCtrl+Q',
+      click: function () {
+        app.quit()
+      }
+    }
+  ]
+
+  if (process.platform === 'darwin') {
+    vmdSubmenu = [
+      {
+        label: 'About vmd',
+        selector: 'orderFrontStandardAboutPanel:'
+      },
+      {
+        type: 'separator'
+      }
+    ].concat(vmdSubmenu)
+  }
+
+  // Doc: https://github.com/atom/electron/blob/master/docs/api/menu-item.md
+  var template = [
+    {
+      label: 'vmd',
+      submenu: vmdSubmenu
+    },
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'Print',
+          accelerator: 'CmdOrCtrl+P',
+          click: function (item, win) {
+            win.webContents.send('print')
+          }
+        }
+      ]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        {
+          label: 'Copy',
+          accelerator: 'CmdOrCtrl+C',
+          role: 'copy'
+        },
+        {
+          label: 'Select All',
+          accelerator: 'CmdOrCtrl+A',
+          role: 'selectall'
+        }
+      ]
+    },
+    {
+      label: 'History',
+      submenu: [
+        {
+          label: 'Back',
+          accelerator: 'Alt+Left',
+          click: function (item, win) {
+            win.webContents.send('history-back')
+          }
+        },
+        {
+          label: 'Forward',
+          accelerator: 'Alt+Right',
+          click: function (item, win) {
+            win.webContents.send('history-forward')
+          }
+        }
+      ]
+    },
+    {
+      label: 'View',
+      submenu: [
+        {
+          label: 'Zoom In',
+          accelerator: 'CmdOrCtrl+Plus',
+          click: function (item, win) {
+            win.webContents.send('zoom-in')
+          }
+        },
+        {
+          label: 'Zoom Out',
+          accelerator: 'CmdOrCtrl+-',
+          click: function (item, win) {
+            win.webContents.send('zoom-out')
+          }
+        },
+        {
+          label: 'Reset Zoom',
+          accelerator: 'CmdOrCtrl+0',
+          click: function (item, win) {
+            win.webContents.send('zoom-reset')
+          }
+        },
+        {
+          label: 'Toggle Developer Tools',
+          accelerator: (function () {
+            if (process.platform === 'darwin') {
+              return 'Alt+Command+I'
+            } else {
+              return 'Ctrl+Shift+I'
+            }
+          })(),
+          click: function (item, focusedWindow) {
+            if (focusedWindow) {
+              focusedWindow.toggleDevTools()
+            }
+          }
+        }
+      ]
+    }
+  ]
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+}


### PR DESCRIPTION
This moves the creation of the application menu from the renderer (`client.js`) in to the main process (`server.js`).

Now that vmd supports multiple windows (#58), adding the application menu in the renderer process will add it over and over every time a new is opened. When a window is then closed this will cause problems (#59) because menus can't be "unregistered" in Electron. Maybe they're not supposed to be set multiple times.

In order for the renderer to communicate with the main process, a new `vmd` API (`api.js`) is injected in to every window as a "preload script". It's available just like any other browser API. The API communicates with the main process over IPC but it's transparent to the client.

client.js:
```js
// open (and watch) a different markdown file in the same window:
vmd.changeFile('/path/to/file.md')

// open (and watch) a different markdown file in a NEW window:
vmd.openFile('/path/to/file.md')

// handle the print action
vmd.onPrintAction(function () {
  console.log('woah, somebody clicked "print" in the menu!')
  window.print()
})

// ... and so on
```