### PR TITLE
Add emoji support

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,7 +1,5 @@
 /*global vmd:true*/
 
-const highlightjs = require('highlight.js')
-const marked = require('marked')
 const remote = require('electron').remote
 const url = remote.require('url')
 const path = remote.require('path')
@@ -12,6 +10,7 @@ const MenuItem = remote.MenuItem
 const clipboard = remote.clipboard
 const conf = remote.getGlobal('conf')
 const currentWindow = remote.getCurrentWindow()
+const renderMarkdown = require('./render-markdown')
 const hist = require('./history')()
 const zoom = require('./zoom')(conf.zoom)
 
@@ -166,12 +165,6 @@ function handleLink (ev) {
   }
 }
 
-marked.setOptions({
-  highlight: function (code, lang) {
-    return highlightjs.highlightAuto(code, [lang]).value
-  }
-})
-
 vmd.onPrintAction(function () {
   window.print()
 })
@@ -189,7 +182,7 @@ vmd.onHistoryForwardAction(function () {
 })
 
 vmd.onContent(function (ev, data) {
-  const md = marked(data.contents)
+  const md = renderMarkdown(data.contents)
   const body = document.body
   const base = document.querySelector('base')
   const mdBody = document.querySelector('.markdown-body')

--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
       margin: 0 auto;
       padding: 30px;
     }
+
+    img[src^="emoji"] {
+      height: 1.5em;
+    }
   </style>
   <base>
 <body>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "chokidar": "^1.4.1",
     "deep-equal": "^1.0.1",
     "electron-prebuilt": "0.36.2",
+    "emojify.js": "^1.1.0",
     "get-stdin": "^5.0.1",
     "github-markdown-css": "^2.1.1",
     "highlight.js": "^9.0.0",

--- a/render-markdown.js
+++ b/render-markdown.js
@@ -1,0 +1,51 @@
+const marked = require('marked')
+const highlightjs = require('highlight.js')
+
+const emojiRegex = /:([A-Za-z0-9_\-\+\xff]+?):/g
+
+function escapeUnderscore (str) {
+  return str.replace(/[_]/g, '\xff')
+}
+
+function unescapeUnderscore (str) {
+  return str.replace(/[\xff]/g, '_')
+}
+
+function escapeEmoji (str) {
+  return str.replace(emojiRegex, function (match, emojiname) {
+    return ':' + escapeUnderscore(emojiname) + ':'
+  })
+}
+
+function unescapeEmoji (str) {
+  return str.replace(emojiRegex, function (match, emojiname) {
+    return ':' + unescapeUnderscore(emojiname) + ':'
+  })
+}
+
+var renderer = new marked.Renderer()
+
+renderer.text = function (text) {
+  return text.replace(emojiRegex, function (match, emojiname) {
+    emojiname = unescapeUnderscore(emojiname)
+    return '<img alt=":' + emojiname + ':" src="emoji://' + emojiname + '" />'
+  })
+}
+
+var originalInlineOutput = marked.InlineLexer.prototype.output
+
+marked.InlineLexer.prototype.output = function (src) {
+  src = escapeEmoji(src)
+  return unescapeEmoji(originalInlineOutput.call(this, src))
+}
+
+marked.setOptions({
+  renderer: renderer,
+  highlight: function (code, lang) {
+    return highlightjs.highlightAuto(code, [lang]).value
+  }
+})
+
+module.exports = function (src) {
+  return marked(src)
+}

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+const path = require('path')
+const url = require('url')
 const app = require('electron').app
 const crashReporter = require('electron').crashReporter
 const Menu = require('electron').Menu
@@ -16,6 +18,7 @@ app.on('window-all-closed', function () {
 })
 
 app.on('ready', function () {
+  registerEmojiProtocol()
   addApplicationMenu()
 
   if (!fromFile) {
@@ -33,6 +36,26 @@ app.on('ready', function () {
     })
   }
 })
+
+function registerEmojiProtocol () {
+  const protocol = require('electron').protocol
+  const emojiPath = path.resolve(path.dirname(require.resolve('emojify.js')), '..', 'images', 'basic')
+
+  protocol.registerFileProtocol(
+    'emoji',
+    function (req, callback) {
+      var emoji = url.parse(req.url).hostname
+      callback({
+        path: path.join(emojiPath, emoji + '.png')
+      })
+    },
+    function (err) {
+      if (err) {
+        console.error('failed to register protocol')
+      }
+    }
+  )
+}
 
 function addApplicationMenu () {
   // menu


### PR DESCRIPTION
Adds support for Emoji. It patches the inline lexer of `marked` and replaces underscores in emoji codes with a placeholder so that emoji with an underscore (e.g. `:simple_smile:`) don't get split up into two tokens. Then a custom `marked.Renderer` implements the `text()` method where emoji codes are replaced with image tags.

I think this is faster than using [roaster](https://www.npmjs.com/package/roaster) that was mentioned in #27. Roaster uses [cheerio](https://github.com/cheeriojs/cheerio) which does way too much for our purpose. But I haven't actually benchmarked it or anything.

The Emoji images are from [emojify.js](https://github.com/Ranks/emojify.js/tree/master/dist/images/basic) and are served using a [custom file protocol sheme](https://github.com/atom/electron/blob/master/docs/api/protocol.md#protocolregisterfileprotocolscheme-handler-completion). So `<img src="emoji://raised-hands" />` shows an actual image.

![screenshot](https://cloud.githubusercontent.com/assets/168709/12081996/a2f9452c-b28a-11e5-9535-e10ab469192a.png)