### PR TITLE
remove crash reporter to fix latest electron donwload

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,13 +1,10 @@
 const path = require('path')
 const url = require('url')
 const app = require('electron').app
-const crashReporter = require('electron').crashReporter
 const Menu = require('electron').Menu
 const getStdin = require('get-stdin')
 const createWindow = require('./create-window')
 const conf = global.conf = require('./config')
-
-crashReporter.start()
 
 const filePath = conf._[0]
 const fromFile = Boolean(filePath)


### PR DESCRIPTION
Fixes #64 for me. I'm not sure why this is necessary now (haven't looked at new Electron docs) so maybe there is a better solve than this.