### PR TITLE
Support for custom styles (fixes #19)

### DIFF
--- a/create-window.js
+++ b/create-window.js
@@ -1,10 +1,10 @@
 const path = require('path')
 const fs = require('fs')
-const app = require('electron').app
 const BrowserWindow = require('electron').BrowserWindow
 const ipc = require('electron').ipcMain
 const chokidar = require('chokidar')
 const assign = require('object-assign')
+const styles = require('./styles')
 
 const defaultOptions = {
   width: 800,
@@ -116,28 +116,6 @@ module.exports = function createWindow (options) {
     }
   }
 
-  function getHighlightTheme (theme) {
-    var themePath = path.resolve(require.resolve('highlight.js'), '../..', 'styles', theme + '.css')
-
-    try {
-      return fs.readFileSync(themePath, 'utf-8')
-    } catch (ex) {
-      console.error('Cannot load theme', theme + ':', ex.code === 'ENOENT' ? 'no such file' : ex.message)
-      app.exit(1)
-    }
-  }
-
-  function getStylesheet (filePath) {
-    var stylePath = path.resolve(filePath)
-
-    try {
-      return fs.readFileSync(stylePath, 'utf-8')
-    } catch (ex) {
-      console.error('Cannot load style', filePath + ':', ex.code === 'ENOENT' ? 'no such file' : ex.message)
-      app.exit(1)
-    }
-  }
-
   function temporarilyInterceptFileProtocol () {
     // very hacky way to dynamically create index.html
     const protocol = require('electron').protocol
@@ -148,16 +126,16 @@ module.exports = function createWindow (options) {
       'file',
       function (req, callback) {
         var mainStyle = options.mainStylesheet
-          ? getStylesheet(options.mainStylesheet)
-          : getStylesheet('node_modules/github-markdown-css/github-markdown.css')
+          ? styles.getStylesheet(options.mainStylesheet)
+          : styles.getStylesheet('node_modules/github-markdown-css/github-markdown.css')
 
         var extraStyle = options.extraStylesheet
-          ? getStylesheet(options.extraStylesheet)
+          ? styles.getStylesheet(options.extraStylesheet)
           : ''
 
         var highlightStyle = options.highlightStylesheet
-          ? getStylesheet(options.highlightStylesheet)
-          : getHighlightTheme('default') + '\n' + getHighlightTheme(options.highlightTheme)
+          ? styles.getStylesheet(options.highlightStylesheet)
+          : styles.getHighlightTheme('default') + '\n' + styles.getHighlightTheme(options.highlightTheme)
 
         var data = {
           mainStyle: mainStyle,

--- a/defaults.yml
+++ b/defaults.yml
@@ -1,3 +1,5 @@
 ---
 document: README.md
 zoom: 1
+highlight:
+  theme: github

--- a/index.html
+++ b/index.html
@@ -1,13 +1,6 @@
 <head>
-  <link
-    rel="stylesheet"
-    href="node_modules/github-markdown-css/github-markdown.css">
-  <link
-    rel="stylesheet"
-    href="node_modules/highlight.js/styles/default.css">
-  <link
-    rel="stylesheet"
-    href="node_modules/highlight.js/styles/github.css">
+  <style><%= mainStyle %></style>
+  <style><%= highlightStyle %></style>
   <style>
     body {
       overflow-y: auto!important;
@@ -41,6 +34,7 @@
       width: 20px;
     }
   </style>
+  <style><%= extraStyle %></style>
   <base>
 <body>
   <div class="markdown-body"></div>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash.template": "^3.6.2",
     "marked": "^0.3.3",
     "object-assign": "^4.0.1",
-    "rucola": "^1.1.2"
+    "rucola": "^1.1.3"
   },
   "devDependencies": {
     "standard": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "get-stdin": "^5.0.1",
     "github-markdown-css": "^2.1.1",
     "highlight.js": "^9.0.0",
+    "lodash.template": "^3.6.2",
     "marked": "^0.3.3",
     "object-assign": "^4.0.1",
     "rucola": "^1.1.2"

--- a/server.js
+++ b/server.js
@@ -51,7 +51,11 @@ app.on('ready', function () {
   addApplicationMenu()
 
   var windowOptions = {
-    devTools: conf.devtools
+    devTools: conf.devtools,
+    mainStylesheet: conf.get('styles.main'),
+    extraStylesheet: conf.get('styles.extra'),
+    highlightTheme: conf.get('highlight.theme'),
+    highlightStylesheet: conf.get('highlight.stylesheet')
   }
 
   if (!fromFile) {

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const getStdin = require('get-stdin')
 const pkg = require('./package.json')
 const createWindow = require('./create-window')
 const conf = global.conf = require('./config')
+const styles = require('./styles')
 
 if (conf.version) {
   console.log(pkg.version)
@@ -21,6 +22,15 @@ if (conf.versions) {
   console.log('v8:       ', process.versions['v8'])
   console.log('openssl:  ', process.versions['openssl'])
   console.log('zlib:     ', process.versions['zlib'])
+  app.exit(0)
+}
+
+if (conf.get('list.highlight.themes')) {
+  console.log('Available highlight.js themes:')
+  styles.getHighlightThemes()
+    .forEach(function (name) {
+      console.log(' - ' + name)
+    })
   app.exit(0)
 }
 

--- a/styles.js
+++ b/styles.js
@@ -1,0 +1,41 @@
+const path = require('path')
+const fs = require('fs')
+const app = require('electron').app
+
+exports.getHighlightThemes = function () {
+  var themesPath = path.resolve(require.resolve('highlight.js'), '../..', 'styles')
+
+  try {
+    return fs.readdirSync(themesPath)
+      .filter(function (name) {
+        return path.extname(name) === '.css' && name !== 'default.css'
+      })
+      .map(function (name) {
+        return path.basename(name, '.css')
+      })
+  } catch (ex) {
+    return []
+  }
+}
+
+exports.getHighlightTheme = function (theme) {
+  var themePath = path.resolve(require.resolve('highlight.js'), '../..', 'styles', theme + '.css')
+
+  try {
+    return fs.readFileSync(themePath, 'utf-8')
+  } catch (ex) {
+    console.error('Cannot load theme', theme + ':', ex.code === 'ENOENT' ? 'no such file' : ex.message)
+    app.exit(1)
+  }
+}
+
+exports.getStylesheet = function (filePath) {
+  var stylePath = path.resolve(filePath)
+
+  try {
+    return fs.readFileSync(stylePath, 'utf-8')
+  } catch (ex) {
+    console.error('Cannot load style', filePath + ':', ex.code === 'ENOENT' ? 'no such file' : ex.message)
+    app.exit(1)
+  }
+}


### PR DESCRIPTION
Fixes #19

This add support for custom styles in four ways:

 - Set the main style (replaces GitHub styles)
 - Set additional styles (override parts of the GitHub styles)
 - Specify the highlight.js theme for syntax highlighting (default: github)
 - Specify a stylesheet for syntax highlighting (instead of a theme)

Command-line options:

`vmd --list-highlight-themes`: prints a list of available highlight.js themes.

 - `--styles-main=<path>`: sets the main stylesheet
 - `--styles-extra=<path>`: sets the additional stylesheet
 - `--highlight-theme=<name>`: sets the syntax highlighting theme
 - `--highlight-stylesheet=<path>`: sets the syntax highlighting stylesheet

This can also be put in your `~/.vmdrc`:

_(yaml style)_
```yaml
styles:
  extra: /home/me/my-vmd-styles-fixes.css
highlight:
  theme: monokai
```

_(ini style)_
```ini
styles.extra = /home/me/my-vmd-styles-fixes.css
highlight.theme = monokai
```