### PR TITLE
Added -t, --title=TITLE switch

### DIFF
--- a/main/config.js
+++ b/main/config.js
@@ -6,6 +6,7 @@ const defaults = fs.readFileSync(path.join(__dirname, '../defaults.yml'), 'utf-8
 const aliases = {
   v: 'version',
   h: 'help',
+  t: 'title',
   d: 'devtools',
   z: 'zoom'
 }

--- a/main/create-window.js
+++ b/main/create-window.js
@@ -86,9 +86,13 @@ module.exports = function createWindow (options) {
   }
 
   function updateTitle () {
-    var prefix = fromFile ? (path.basename(options.filePath) + ' - ') : ''
+    if (options.title) {
+      win.setTitle(options.title)
+    } else {
+      var prefix = fromFile ? (path.basename(options.filePath) + ' - ') : ''
 
-    win.setTitle(prefix + 'vmd')
+      win.setTitle(prefix + 'vmd')
+    }
 
     // (OS X) Set represented filename (icon in title bar)
     if (fromFile && process.platform === 'darwin') {

--- a/main/create-window.js
+++ b/main/create-window.js
@@ -86,13 +86,11 @@ module.exports = function createWindow (options) {
   }
 
   function updateTitle () {
-    if (options.title) {
-      win.setTitle(options.title)
-    } else {
-      var prefix = fromFile ? (path.basename(options.filePath) + ' - ') : ''
+    var prefix =
+      options.title ||
+      (fromFile && (path.basename(options.filePath)))
 
-      win.setTitle(prefix + 'vmd')
-    }
+    win.setTitle(prefix ? prefix + ' - vmd' : 'vmd')
 
     // (OS X) Set represented filename (icon in title bar)
     if (fromFile && process.platform === 'darwin') {

--- a/main/main.js
+++ b/main/main.js
@@ -83,6 +83,7 @@ app.on('ready', function () {
 function createWindowOptions (fromFile, fileOrContent) {
   var windowOptions = {
     devTools: conf.devtools,
+    title: conf.title,
     mainStylesheet: conf.get('styles.main'),
     extraStylesheet: conf.get('styles.extra'),
     highlightTheme: conf.get('highlight.theme'),

--- a/usage.txt
+++ b/usage.txt
@@ -14,6 +14,8 @@ Options:
 
   -h, --help                       Show this help.
 
+  -t, --title=TITLE                Set window title.
+
   -d, --devtools                   Open developer tools.
 
   -z, --zoom=NUM                   Set the zoom factor. Default: 1


### PR DESCRIPTION
Especially useful when rendering from `stdin`.

I'm using it in simple shell script:
```bash
#!/bin/bash
daemonize npm show "$1" readme | vmd --title="$1" &> /dev/null &
```
which shows me npm package README. It's more descriptive than plain vmd title :-)