### PR TITLE
Fix app crashing due to file not found

### DIFF
--- a/main/create-window.js
+++ b/main/create-window.js
@@ -143,7 +143,7 @@ module.exports = function createWindow (options) {
       function (req, callback) {
         var mainStyle = options.mainStylesheet
           ? styles.getStylesheet(options.mainStylesheet)
-          : styles.getStylesheet(path.resolve(__dirname, '../node_modules/github-markdown-css/github-markdown.css'))
+          : styles.getStylesheet(require.resolve('github-markdown-css'))
 
         var extraStyle = options.extraStylesheet
           ? styles.getStylesheet(options.extraStylesheet)


### PR DESCRIPTION
* If we are using latest npm, we can't guaranty that, all the dependencies will exists inside <AppDir>/node_modules directory. App was crashing due to this error.
* I think This patch is using more cleaner way to resolve a module path