### PR TITLE
Restore last vmd session's window state on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ $ gh-rtfm substack/node-browserify | vmd
  - `--highlight-stylesheet=FILE`: Provide a custom CSS file for syntax
    highlighting in code blocks.
 
+ - `--window-preservestate=false`: By default vmd preserves the window state
+   for the next session, set this option to false to disable this.
+
 ## Configuration
 
 All [Options](#options) that contain a value can be persisted in configuration

--- a/defaults.yml
+++ b/defaults.yml
@@ -3,3 +3,5 @@ document: README.md
 zoom: 1
 highlight:
   theme: github
+window:
+  preservestate: true

--- a/main/create-window.js
+++ b/main/create-window.js
@@ -10,6 +10,7 @@ const windowStateKeeper = require('electron-window-state')
 
 module.exports = function createWindow (options) {
   const mainWindowState = windowStateKeeper({
+    file: 'vmd-window-state.json',
     defaultWidth: 800,
     defaultHeight: 600
   })

--- a/main/create-window.js
+++ b/main/create-window.js
@@ -8,14 +8,26 @@ const sharedState = require('../shared/shared-state')
 const styles = require('./styles')
 const windowStateKeeper = require('electron-window-state')
 
-module.exports = function createWindow (options) {
-  const mainWindowState = windowStateKeeper({
-    file: 'vmd-window-state.json',
-    defaultWidth: 800,
-    defaultHeight: 600
-  })
+const defaultOptions = {
+  width: 800,
+  height: 600,
+  x: undefined,
+  y: undefined
+}
 
-  options = assign({}, mainWindowState, options)
+module.exports = function createWindow (options) {
+  const preservestate = options.window.preservestate && options.window.preservestate !== 'false'
+
+  if (preservestate) {
+    var mainWindowState = windowStateKeeper({
+      file: 'vmd-window-state.json',
+      defaultWidth: defaultOptions.width,
+      defaultHeight: defaultOptions.height
+    })
+    options = assign({}, mainWindowState, options)
+  } else {
+    options = assign({}, defaultOptions, options)
+  }
 
   const fromFile = typeof options.filePath !== 'undefined'
   var watcher
@@ -32,8 +44,6 @@ module.exports = function createWindow (options) {
     x: options.x,
     y: options.y
   })
-
-  mainWindowState.manage(win)
 
   updateTitle()
 
@@ -52,6 +62,10 @@ module.exports = function createWindow (options) {
 
   if (win.isFocused()) {
     sharedState.setFocusedWindow(win.id)
+  }
+
+  if (preservestate) {
+    mainWindowState.manage(win)
   }
 
   if (options.devTools) {

--- a/main/create-window.js
+++ b/main/create-window.js
@@ -6,14 +6,15 @@ const chokidar = require('chokidar')
 const assign = require('object-assign')
 const sharedState = require('../shared/shared-state')
 const styles = require('./styles')
-
-const defaultOptions = {
-  width: 800,
-  height: 600
-}
+const windowStateKeeper = require('electron-window-state')
 
 module.exports = function createWindow (options) {
-  options = assign({}, defaultOptions, options)
+  const mainWindowState = windowStateKeeper({
+    defaultWidth: 800,
+    defaultHeight: 600
+  })
+
+  options = assign({}, mainWindowState, options)
 
   const fromFile = typeof options.filePath !== 'undefined'
   var watcher
@@ -26,8 +27,12 @@ module.exports = function createWindow (options) {
     },
     icon: path.join(__dirname, 'assets/app-icon/png/512.png'),
     width: options.width,
-    height: options.height
+    height: options.height,
+    x: options.x,
+    y: options.y
   })
+
+  mainWindowState.manage(win)
 
   updateTitle()
 

--- a/main/main.js
+++ b/main/main.js
@@ -94,6 +94,7 @@ function createWindowOptions (fromFile, fileOrContent) {
   var windowOptions = {
     devTools: conf.devtools,
     title: conf.title,
+    window: conf.window,
     mainStylesheet: conf.get('styles.main'),
     extraStylesheet: conf.get('styles.extra'),
     highlightTheme: conf.get('highlight.theme'),

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chokidar": "1.6.0",
     "deep-equal": "1.0.1",
     "electron": "1.3.2",
+    "electron-window-state": "3.0.4",
     "emojify.js": "1.1.0",
     "get-stdin": "5.0.1",
     "github-markdown-css": "2.4.0",


### PR DESCRIPTION
Saves the state of the vmd window on save and then restores it when vmd is opened again.

Is a feature I wanted as the first thing I always do when calling `vmd` is move the window.