### PR TITLE
If passed a directory, open its README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ When no path to a document is supplied, "README.md" will be opened by default:
 $ vmd
 ```
 
+When a path to a directory is supplied, "directory/README.md" will be opened by default:
+
+```sh
+$ vmd node_modules/electron # opens node_modules/electron/README.md
+```
+
 It reads from `stdin` so you can pipe markdown text in to it:
 
 ```sh

--- a/main/main.js
+++ b/main/main.js
@@ -53,6 +53,11 @@ if (fromFile) {
     var stat = fs.statSync(path.resolve(filePath))
 
     if (stat.isDirectory()) {
+      filePath = path.resolve(filePath, conf.document)
+      stat = fs.statSync(filePath)
+    }
+
+    if (stat.isDirectory()) {
       console.error('Cannot open', filePath + ': is a directory')
       app.exit(1)
     }


### PR DESCRIPTION
This makes it easier to run, for example:

    vmd node_modules/electron