### PR TITLE
make markdown-body class wider, fixes #105

### DIFF
--- a/renderer/vmd.html
+++ b/renderer/vmd.html
@@ -22,7 +22,7 @@
 
     .markdown-body {
       min-width: 200px;
-      max-width: 790px;
+      max-width: 970px;
       margin: 0 auto;
       padding: 30px;
     }


### PR DESCRIPTION
So to be consistent with the current github readme style width.


fixes #105