### PR TITLE
Ignore front-matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ $ gh-rtfm substack/node-browserify | vmd
  - `--window-autohidemenubar=true`: By default vmd always shows the menu bar.
    To hide it set this flag to `true`. The menu visibility can be toggled using
    the `Alt` key. Linux and Windows only.
+ - `--ignorefrontmatter={format1, format2}`: By default vmd ignores `yaml` frontmatter.
+   You can configure it to ignore other formats supported by [remark-frontmatter](https://github.com/wooorm/remark-frontmatter).
 
 ## Configuration
 
@@ -173,7 +175,7 @@ values in the configuration file. So `--zoom=1.5` will set the zoom factor to
 
 ## Authors
 
-[Max Kueng](https://github.com/maxkueng), [Yoshua Wuyts](https://github.com/yoshuawuyts) 
+[Max Kueng](https://github.com/maxkueng), [Yoshua Wuyts](https://github.com/yoshuawuyts)
 and [contributors](https://github.com/yoshuawuyts/vmd/graphs/contributors).
 
 ## License

--- a/defaults.yml
+++ b/defaults.yml
@@ -6,3 +6,5 @@ highlight:
 window:
   preservestate: true
   autohidemenubar: false
+ignorefrontmatter:
+  - yaml

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "redux": "^3.7.2",
     "remark": "8.0.0",
     "remark-emoji-to-gemoji": "^1.1.0",
+    "remark-frontmatter": "^1.1.0",
     "remark-highlight.js": "5.0.0",
     "remark-html": "6.0.1",
     "remark-slug": "^4.2.3",

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -313,7 +313,7 @@ vmd.onContent((ev, data) => {
       mdBody = document.querySelector('.markdown-body');
     }
 
-    renderMarkdown(data.contents, (err, file) => {
+    renderMarkdown(data.contents, conf, (err, file) => {
       if (err) {
         console.error(err);
       }

--- a/renderer/render-markdown.js
+++ b/renderer/render-markdown.js
@@ -7,6 +7,7 @@ const emojiToGemoji = require('remark-emoji-to-gemoji');
 const html = require('remark-html');
 const visit = require('unist-util-visit');
 const toString = require('mdast-util-to-string');
+const remarkFrontmatter = require('remark-frontmatter');
 
 const emojiPath = path.resolve(path.dirname(require.resolve('emojify.js')), '..', 'images', 'basic');
 
@@ -164,16 +165,24 @@ function fixCheckListStyles() {
   };
 }
 
-const renderer = remark()
-  .use(emojiToGemoji)
-  .use(gemojiToImages)
-  .use(fixHeadings)
-  .use(fixCheckListStyles)
-  .use(slug)
-  .use([hljs, html], {
-    sanitize: false,
-  });
+function frontmatter(fmts) {
+  if (!fmts.length) {
+    return [() => {}];
+  }
 
-module.exports = function renderMarkdown(text, callback) {
-  renderer.process(text, callback);
+  return [remarkFrontmatter, fmts];
+}
+
+module.exports = function renderMarkdown(text, opts, callback) {
+  remark()
+    .use(emojiToGemoji)
+    .use(gemojiToImages)
+    .use(fixHeadings)
+    .use(fixCheckListStyles)
+    .use(slug)
+    .use(...frontmatter(opts.ignorefrontmatter))
+    .use([hljs, html], {
+      sanitize: false,
+    })
+    .process(text, callback);
 };

--- a/renderer/render-markdown.js
+++ b/renderer/render-markdown.js
@@ -167,10 +167,10 @@ function fixCheckListStyles() {
 
 function frontmatter(fmts) {
   if (!fmts.length) {
-    return [() => {}];
+    return () => {};
   }
 
-  return [remarkFrontmatter, fmts];
+  return remarkFrontmatter.bind(this)(fmts);
 }
 
 module.exports = function renderMarkdown(text, opts, callback) {
@@ -180,7 +180,7 @@ module.exports = function renderMarkdown(text, opts, callback) {
     .use(fixHeadings)
     .use(fixCheckListStyles)
     .use(slug)
-    .use(...frontmatter(opts.ignorefrontmatter))
+    .use(frontmatter, opts.ignorefrontmatter)
     .use([hljs, html], {
       sanitize: false,
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,6 +801,12 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fault@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.1.tgz#de8d350dfd48be24b5dc1b02867e0871b9135092"
+  dependencies:
+    format "^0.2.2"
+
 fd-slicer@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
@@ -881,6 +887,10 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+format@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
 
 fs-extra@0.26.7:
   version "0.26.7"
@@ -2158,6 +2168,13 @@ remark-emoji-to-gemoji@^1.1.0:
     escape-string-regexp "^1.0.5"
     gemoji "^4.0.0"
     unist-util-visit "^1.0.0"
+
+remark-frontmatter@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-1.1.0.tgz#9d23c2b376f56617bdb5c5560f1b56e45b19788b"
+  dependencies:
+    fault "^1.0.1"
+    xtend "^4.0.1"
 
 remark-highlight.js@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Currently `vmd` tries to parse front-matter as it's a valid markdown. This PR adds a feature of ignoring front-matter. By default it's configured to ignore *yaml* front-matter, but there is an option to set the list of ignored formats.