### PR TITLE
Render Front Matter as nested table like on GitHub (fixes #111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ same as on GitHub.
    make vmd look the way you want. Take a look at the [Options](#options) for
    an overview of available customization options.
 
+ - **Front Matter**: Renders [Front Matter][frontmatter] so you can preview
+   your Jekyll and Hugo content in vmd.
+
 ## Installation
 
 ```bash
@@ -147,8 +150,9 @@ $ gh-rtfm substack/node-browserify | vmd
  - `--window-autohidemenubar=true`: By default vmd always shows the menu bar.
    To hide it set this flag to `true`. The menu visibility can be toggled using
    the `Alt` key. Linux and Windows only.
- - `--ignorefrontmatter={format1, format2}`: By default vmd ignores `yaml` frontmatter.
-   You can configure it to ignore other formats supported by [remark-frontmatter](https://github.com/wooorm/remark-frontmatter).
+
+ - `--frontmatter-fromats=FORMATS`: A comma-separated list of Front Matter
+   formats. By default only the YAML format is enabled.
 
 ## Configuration
 
@@ -191,3 +195,4 @@ and [contributors](https://github.com/yoshuawuyts/vmd/graphs/contributors).
 [emoji-cheat-sheet]: http://www.emoji-cheat-sheet.com/
 [codacy-image]: https://img.shields.io/codacy/grade/ccaa489b6f664ebd9a12d900334be10f/master.svg?style=flat-square
 [codacy-url]: https://www.codacy.com/app/maxkueng/vmd?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=yoshuawuyts/vmd&amp;utm_campaign=Badge_Grade
+[frontmatter]: https://jekyllrb.com/docs/frontmatter/

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ $ gh-rtfm substack/node-browserify | vmd
    formats. By default only the YAML format is enabled. Supported formats are
    YAML, TOML.
 
+ - `--frontmatter-renderer=RENDERER`: Specify how to render Front Matter. Can
+   be “table”, “code” or “none”. If “none” is specified the Front Matter will
+   not be rendered at all. Default is “table”.
+
 ## Configuration
 
 All [Options](#options) that contain a value can be persisted in configuration

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ $ gh-rtfm substack/node-browserify | vmd
    the `Alt` key. Linux and Windows only.
 
  - `--frontmatter-fromats=FORMATS`: A comma-separated list of Front Matter
-   formats. By default only the YAML format is enabled.
+   formats. By default only the YAML format is enabled. Supported formats are
+   YAML, TOML.
 
 ## Configuration
 

--- a/defaults.yml
+++ b/defaults.yml
@@ -8,3 +8,4 @@ window:
   autohidemenubar: false
 frontmatter:
   formats: yaml
+  renderer: table

--- a/defaults.yml
+++ b/defaults.yml
@@ -6,5 +6,5 @@ highlight:
 window:
   preservestate: true
   autohidemenubar: false
-ignorefrontmatter:
-  - yaml
+frontmatter:
+  formats: yaml

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "remark-html": "6.0.1",
     "remark-slug": "^4.2.3",
     "rucola": "^1.1.3",
+    "toml": "^2.3.3",
     "unist-util-visit": "^1.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "emojify.js": "^1.1.0",
     "get-stdin": "^5.0.1",
     "github-markdown-css": "^2.8.0",
+    "js-yaml": "^3.10.0",
     "lodash.template": "^4.4.0",
     "mdast-util-to-string": "^1.0.4",
     "minimist": "^1.2.0",

--- a/renderer/render-markdown.js
+++ b/renderer/render-markdown.js
@@ -233,7 +233,6 @@ function renderFrontMatter() {
           const getNode = () => {
             try {
               const doc = parse(node.value);
-              console.log(doc);
               return objectToMdastTable(doc);
             } catch (err) {
               return {

--- a/renderer/render-markdown.js
+++ b/renderer/render-markdown.js
@@ -7,7 +7,8 @@ const emojiToGemoji = require('remark-emoji-to-gemoji');
 const html = require('remark-html');
 const visit = require('unist-util-visit');
 const toString = require('mdast-util-to-string');
-const remarkFrontmatter = require('remark-frontmatter');
+const frontmatter = require('remark-frontmatter');
+const yaml = require('js-yaml');
 
 const emojiPath = path.resolve(path.dirname(require.resolve('emojify.js')), '..', 'images', 'basic');
 
@@ -165,22 +166,109 @@ function fixCheckListStyles() {
   };
 }
 
-function frontmatter(fmts) {
-  if (!fmts.length) {
-    return () => {};
+function objectToMdastTable(obj) {
+  const isObject = Object.prototype.toString.call(obj) === '[object Object]';
+  const isArray = Array.isArray(obj);
+
+  if (!isObject && !isArray) {
+    return {
+      type: 'text',
+      value: String(obj),
+    };
   }
 
-  return remarkFrontmatter.bind(this)(fmts);
+  const createTable = (columnCount, children) => ({
+    type: 'table',
+    data: {
+      hProperties: {
+        className: 'frontmatter',
+      },
+    },
+    align: new Array(columnCount).fill('center'),
+    children,
+  });
+
+  const createRow = children => ({
+    type: 'tableRow',
+    children,
+  });
+
+  const createCell = (nodeType, value) => ({
+    type: 'tableCell',
+    data: {
+      hName: nodeType,
+    },
+    children: [
+      value,
+    ],
+  });
+
+  if (isObject) {
+    const head = Object.keys(obj).map(key => createCell('th', {
+      type: 'text',
+      value: key,
+    }));
+
+    const body = Object.keys(obj).map(key => createCell('td', objectToMdastTable(obj[key])));
+
+    return createTable(head.length, [
+      createRow(head),
+      createRow(body),
+    ]);
+  }
+
+  const body = obj.map(value => createCell('td', objectToMdastTable(value)));
+
+  return createTable(body.length, [
+    createRow(body),
+  ]);
 }
 
-module.exports = function renderMarkdown(text, opts, callback) {
+function renderFrontMatter() {
+  return function transformer(tree) {
+    visit(tree, 'yaml', (node, nodeIndex, parent) => {
+      if (parent.type === 'root' && nodeIndex === 0) {
+        const getNode = () => {
+          try {
+            const doc = yaml.safeLoad(node.value);
+            return objectToMdastTable(doc);
+          } catch (err) {
+            return {
+              type: 'code',
+              lang: 'yaml',
+              value: node.value,
+              data: {
+                hProperties: {
+                  title: err.message || err,
+                },
+              },
+            };
+          }
+        };
+
+        // eslint-disable-next-line no-param-reassign
+        parent.children = [].concat(
+          [getNode()],
+          parent.children.slice(nodeIndex + 1),
+        );
+      }
+    });
+  };
+}
+
+module.exports = function renderMarkdown(text, config, callback) {
+  const frontMatters = config.get('frontmatter.formats')
+    .split(',')
+    .map(format => format.toLowerCase());
+
   remark()
     .use(emojiToGemoji)
     .use(gemojiToImages)
     .use(fixHeadings)
     .use(fixCheckListStyles)
     .use(slug)
-    .use(frontmatter, opts.ignorefrontmatter)
+    .use(frontmatter, frontMatters)
+    .use(renderFrontMatter)
     .use([hljs, html], {
       sanitize: false,
     })

--- a/renderer/vmd.html
+++ b/renderer/vmd.html
@@ -65,6 +65,11 @@
       opacity: 1;
       pointer-events: all;
     }
+
+    table.frontmatter {
+      font-size: 12px;
+      line-height: 1;
+    }
   </style>
   <style><%= extraStyle %></style>
   <base>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,6 +1403,13 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js-yaml@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.9.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,6 +2636,10 @@ tmp@^0.0.31:
   dependencies:
     os-tmpdir "~1.0.1"
 
+toml@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.3.tgz#8d683d729577cb286231dfc7a8affe58d31728fb"
+
 touch@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/touch/-/touch-0.0.3.tgz#51aef3d449571d4f287a5d87c9c8b49181a0db1d"


### PR DESCRIPTION
Re: #111 

 - [x] Only enable YAML Front Matter by default
 - [x] Render Front Matter as a nested table
 - [x] Render disabled Front mater styles (i.e. TOML, JSON) as regular text
 - [x] Render Front Matter with errors as a preformatted text block, like a code section

Additional features that can be enabled through configuration:

 - [x] Support TOML Front Matter
 - [ ] ~~Support JSON Front Matter~~ (separate issue #113)
 - [x] Add option to strip Front Matter and not render it