### PR TITLE
Upgrade electron to get rid of SEGFAULT

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "chokidar": "2.0.3",
     "deep-equal": "^1.0.1",
-    "electron": "2.0.2",
+    "electron": "~2.0.13",
     "electron-in-page-search": "1.3.2",
     "electron-window-state": "^4.1.1",
     "emojify.js": "^1.1.0",


### PR DESCRIPTION
Closes https://github.com/yoshuawuyts/vmd/issues/126

Crashes on Ubuntu 18.10 as well.